### PR TITLE
Moved dev dependencies to "devDependencies"

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,14 +27,16 @@
   },
   "homepage": "https://github.com/meerkats/winston-slacker#readme",
   "dependencies": {
+    "request": "^2.61.0",
+    "util-extend": "^1.0.1",
+    "winston": "^1.0.1"
+  },
+  "devDependencies": {
     "babel-eslint": "^4.1.3",
     "eslint": "^1.5.1",
     "eslint-config-meerkats": "*",
     "eslint-plugin-shadow-exception": "^1.1.2",
     "jasmine-node": "^1.14.5",
-    "request": "^2.61.0",
-    "sinon": "^1.16.1",
-    "util-extend": "^1.0.1",
-    "winston": "^1.0.1"
+    "sinon": "^1.16.1"
   }
 }


### PR DESCRIPTION
Packages like eslint, babel, sinon are only needed for development and should not be installed for production.